### PR TITLE
[Feat] test container 환경 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:mysql'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/test/java/com/evenly/blok/BlokApplicationTests.java
+++ b/src/test/java/com/evenly/blok/BlokApplicationTests.java
@@ -2,8 +2,10 @@ package com.evenly.blok;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class BlokApplicationTests {
 
 	@Test

--- a/src/test/java/com/evenly/blok/TestBlokApplication.java
+++ b/src/test/java/com/evenly/blok/TestBlokApplication.java
@@ -1,0 +1,13 @@
+package com.evenly.blok;
+
+import org.springframework.boot.SpringApplication;
+
+import com.evenly.blok.global.config.TestcontainersConfig;
+
+public class TestBlokApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.from(BlokApplication::main).with(TestcontainersConfig.class).run(args);
+	}
+
+}

--- a/src/test/java/com/evenly/blok/global/config/TestcontainersConfig.java
+++ b/src/test/java/com/evenly/blok/global/config/TestcontainersConfig.java
@@ -1,0 +1,21 @@
+package com.evenly.blok.global.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestcontainersConfig {
+
+	@Bean
+	@ServiceConnection
+	MySQLContainer<?> mysqlContainer() {
+		return new MySQLContainer<>(DockerImageName.parse("mysql:8.0.26"))
+			.withDatabaseName("testdb")
+			.withUsername("test")
+			.withPassword("test");
+	}
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,26 @@
+spring:
+  application:
+    name: blok
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:tc:mysql:8.0.26:///testdb
+    username: test
+    password: test
+
+logging:
+  level:
+    org:
+      hibernate:
+        type:
+          descriptor:
+            sql: trace


### PR DESCRIPTION
issue #2 

## 📌 개발 이유

Testcontainers를 활용하여 MySQL 기반의 테스트 환경을 구성하고자 했습니다. 
[TestContainers의 이점 정리](https://www.notion.so/depromeet/TestContainer-b33b39e605e9423baa253fe15affb59c?pvs=4)

## 💻 수정 사항

### **1. `TestcontainersConfiguration`**
- **추가 내용**:
  - `MySQLContainer`를 빈으로 등록하여 테스트 환경에서 MySQL Testcontainer를 사용.
  - `@ServiceConnection`을 통해 Spring Boot와 자동 통합.
  - Docker 이미지: `mysql:8.0.26`.
  - 데이터베이스 이름: `testdb`, 사용자명: `test`, 비밀번호: `test`.

- **수정 이유**:
  - Testcontainers를 통해 테스트 시 독립적인 MySQL 환경을 제공하여 테스트 간 데이터 간섭을 방지하기 위함.

### **2. `BlokApplicationTests`**
- **추가 내용**:
  - `@SpringBootTest`와 `@ActiveProfiles("test")`를 사용하여 테스트 프로파일 활성화.
  - `contextLoads` 테스트 작성.

- **수정 이유**:
  - Spring 애플리케이션 컨텍스트가 정상적으로 로드되는지 확인하기 위한 기본 테스트 작성.

### **3. `TestBlokApplication`**
- **추가 내용**:
  - `SpringApplication.from`을 사용하여 테스트 환경에서 `TestcontainersConfiguration`을 포함한 애플리케이션 실행.

- **수정 이유**:
  - 테스트 환경에서만 특정 설정을 포함하도록 별도의 실행 클래스를 구성.

### **4. `application-test.yml`**
- **수정 이유**:
  - test 환경 분리
