### PR TITLE
[Feat] 전역적 예외 및 핸들러 추가

### DIFF
--- a/src/main/java/com/evenly/blok/global/exception/BlokException.java
+++ b/src/main/java/com/evenly/blok/global/exception/BlokException.java
@@ -1,0 +1,11 @@
+package com.evenly.blok.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BlokException extends RuntimeException { // TODO: 서비스명에 맞게 변경
+
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/evenly/blok/global/exception/CommonErrorCode.java
+++ b/src/main/java/com/evenly/blok/global/exception/CommonErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum CommonErrorCode implements ErrorCode {
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 관리자에게 문의하세요."),
-    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "유효하지 않은 요청값입니다."),
+    INVALID_REQUEST_VALUE(HttpStatus.BAD_REQUEST, "유효하지 않은 요청값입니다."),
+    INVALID_REQUEST_URL(HttpStatus.BAD_REQUEST, "유효하지 않은 경로입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/evenly/blok/global/exception/CommonErrorCode.java
+++ b/src/main/java/com/evenly/blok/global/exception/CommonErrorCode.java
@@ -1,0 +1,21 @@
+package com.evenly.blok.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 관리자에게 문의하세요."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public ErrorResponse getResponse() {
+        return new ErrorResponse(message);
+    }
+}

--- a/src/main/java/com/evenly/blok/global/exception/CommonErrorCode.java
+++ b/src/main/java/com/evenly/blok/global/exception/CommonErrorCode.java
@@ -9,13 +9,9 @@ import org.springframework.http.HttpStatus;
 public enum CommonErrorCode implements ErrorCode {
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 관리자에게 문의하세요."),
+    INVALID_REQUEST(HttpStatus.NOT_FOUND, "유효하지 않은 요청값입니다."),
     ;
 
     private final HttpStatus status;
     private final String message;
-
-    @Override
-    public ErrorResponse getResponse() {
-        return new ErrorResponse(name(), message);
-    }
 }

--- a/src/main/java/com/evenly/blok/global/exception/CommonErrorCode.java
+++ b/src/main/java/com/evenly/blok/global/exception/CommonErrorCode.java
@@ -16,6 +16,6 @@ public enum CommonErrorCode implements ErrorCode {
 
     @Override
     public ErrorResponse getResponse() {
-        return new ErrorResponse(message);
+        return new ErrorResponse(name(), message);
     }
 }

--- a/src/main/java/com/evenly/blok/global/exception/CommonErrorCode.java
+++ b/src/main/java/com/evenly/blok/global/exception/CommonErrorCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum CommonErrorCode implements ErrorCode {
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 관리자에게 문의하세요."),
-    INVALID_REQUEST(HttpStatus.NOT_FOUND, "유효하지 않은 요청값입니다."),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "유효하지 않은 요청값입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/evenly/blok/global/exception/ErrorCode.java
+++ b/src/main/java/com/evenly/blok/global/exception/ErrorCode.java
@@ -1,0 +1,10 @@
+package com.evenly.blok.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+    HttpStatus getStatus();
+
+    ErrorResponse getResponse();
+}

--- a/src/main/java/com/evenly/blok/global/exception/ErrorCode.java
+++ b/src/main/java/com/evenly/blok/global/exception/ErrorCode.java
@@ -6,5 +6,5 @@ public interface ErrorCode {
 
     HttpStatus getStatus();
 
-    ErrorResponse getResponse();
+    String getMessage();
 }

--- a/src/main/java/com/evenly/blok/global/exception/ErrorResponse.java
+++ b/src/main/java/com/evenly/blok/global/exception/ErrorResponse.java
@@ -1,0 +1,4 @@
+package com.evenly.blok.global.exception;
+
+public record ErrorResponse(String message) {
+}

--- a/src/main/java/com/evenly/blok/global/exception/ErrorResponse.java
+++ b/src/main/java/com/evenly/blok/global/exception/ErrorResponse.java
@@ -1,4 +1,5 @@
 package com.evenly.blok.global.exception;
 
-public record ErrorResponse(String message) {
+public record ErrorResponse(String code,
+                            String message) {
 }

--- a/src/main/java/com/evenly/blok/global/exception/ErrorResponse.java
+++ b/src/main/java/com/evenly/blok/global/exception/ErrorResponse.java
@@ -1,5 +1,0 @@
-package com.evenly.blok.global.exception;
-
-public record ErrorResponse(String code,
-                            String message) {
-}

--- a/src/main/java/com/evenly/blok/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/evenly/blok/global/exception/GlobalExceptionHandler.java
@@ -2,7 +2,6 @@ package com.evenly.blok.global.exception;
 
 import com.evenly.blok.global.exception.dto.ErrorResponse;
 import com.evenly.blok.global.exception.dto.ValidationErrorResponse;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,29 +10,22 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler
-    public ResponseEntity<ErrorResponse> handle(BlokException ex) {
-        ErrorResponse response = ErrorResponse.of(ex.getErrorCode());
-        return ResponseEntity
-                .status(response.getStatus())
-                .body(response);
+    public ErrorResponse handle(BlokException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        return ErrorResponse.of(errorCode);
     }
 
     @ExceptionHandler
-    public ResponseEntity<ErrorResponse> handle(MethodArgumentNotValidException ex) {
+    public ErrorResponse handle(MethodArgumentNotValidException ex) {
         ErrorCode errorCode = CommonErrorCode.INVALID_REQUEST;
-        ValidationErrorResponse response = ValidationErrorResponse.of(errorCode, ex);
-        return ResponseEntity
-                .status(response.getStatus())
-                .body(response);
+        return ValidationErrorResponse.of(errorCode, ex);
     }
 
     @ExceptionHandler
-    public ResponseEntity<ErrorResponse> handle(Exception ex) {
-        ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
-        ErrorResponse response = ErrorResponse.of(errorCode);
+    public ErrorResponse handle(Exception ex) {
         // TODO: 로그 추가
-        return ResponseEntity
-                .status(response.getStatus())
-                .body(response);
+        ex.printStackTrace();
+        ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+        return ErrorResponse.of(errorCode);
     }
 }

--- a/src/main/java/com/evenly/blok/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/evenly/blok/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.evenly.blok.global.exception;
 
 import com.evenly.blok.global.exception.dto.ErrorResponse;
+import com.evenly.blok.global.exception.dto.ServerErrorResponse;
 import com.evenly.blok.global.exception.dto.ValidationErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -26,6 +27,6 @@ public class GlobalExceptionHandler {
         // TODO: 로그 추가
         ex.printStackTrace();
         ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
-        return ErrorResponse.of(errorCode);
+        return ServerErrorResponse.of(errorCode, ex);
     }
 }

--- a/src/main/java/com/evenly/blok/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/evenly/blok/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.evenly.blok.global.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponse> handle(BlokException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(errorCode.getResponse());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponse> handle(Exception ex) {
+        ErrorResponse response = new ErrorResponse("서버 관리자에게 문의하세요.");
+        return ResponseEntity
+                .internalServerError()
+                .body(response);
+    }
+}

--- a/src/main/java/com/evenly/blok/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/evenly/blok/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,9 @@
 package com.evenly.blok.global.exception;
 
+import com.evenly.blok.global.exception.dto.ErrorResponse;
+import com.evenly.blok.global.exception.dto.ValidationErrorResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -9,18 +12,28 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler
     public ResponseEntity<ErrorResponse> handle(BlokException ex) {
-        ErrorCode errorCode = ex.getErrorCode();
+        ErrorResponse response = ErrorResponse.of(ex.getErrorCode());
         return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(errorCode.getResponse());
+                .status(response.getStatus())
+                .body(response);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponse> handle(MethodArgumentNotValidException ex) {
+        ErrorCode errorCode = CommonErrorCode.INVALID_REQUEST;
+        ValidationErrorResponse response = ValidationErrorResponse.of(errorCode, ex);
+        return ResponseEntity
+                .status(response.getStatus())
+                .body(response);
     }
 
     @ExceptionHandler
     public ResponseEntity<ErrorResponse> handle(Exception ex) {
         ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+        ErrorResponse response = ErrorResponse.of(errorCode);
         // TODO: 로그 추가
         return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(errorCode.getResponse());
+                .status(response.getStatus())
+                .body(response);
     }
 }

--- a/src/main/java/com/evenly/blok/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/evenly/blok/global/exception/GlobalExceptionHandler.java
@@ -17,9 +17,10 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler
     public ResponseEntity<ErrorResponse> handle(Exception ex) {
-        ErrorResponse response = new ErrorResponse("서버 관리자에게 문의하세요.");
+        ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+        // TODO: 로그 추가
         return ResponseEntity
-                .internalServerError()
-                .body(response);
+                .status(errorCode.getStatus())
+                .body(errorCode.getResponse());
     }
 }

--- a/src/main/java/com/evenly/blok/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/evenly/blok/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.evenly.blok.global.exception.dto.ValidationErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -17,8 +18,14 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler
+    public ErrorResponse handle(NoResourceFoundException ex) {
+        ErrorCode errorCode = CommonErrorCode.INVALID_REQUEST_URL;
+        return ErrorResponse.of(errorCode);
+    }
+
+    @ExceptionHandler
     public ErrorResponse handle(MethodArgumentNotValidException ex) {
-        ErrorCode errorCode = CommonErrorCode.INVALID_REQUEST;
+        ErrorCode errorCode = CommonErrorCode.INVALID_REQUEST_VALUE;
         return ValidationErrorResponse.of(errorCode, ex);
     }
 

--- a/src/main/java/com/evenly/blok/global/exception/dto/ErrorResponse.java
+++ b/src/main/java/com/evenly/blok/global/exception/dto/ErrorResponse.java
@@ -1,0 +1,24 @@
+package com.evenly.blok.global.exception.dto;
+
+import com.evenly.blok.global.exception.ErrorCode;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ErrorResponse {
+
+    private final HttpStatus status;
+    private final String message;
+    private final LocalDateTime timestamp;
+
+    protected ErrorResponse(ErrorCode errorCode) {
+        this.status = errorCode.getStatus();
+        this.message = errorCode.getMessage();
+        this.timestamp = LocalDateTime.now();
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode);
+    }
+}

--- a/src/main/java/com/evenly/blok/global/exception/dto/ServerErrorResponse.java
+++ b/src/main/java/com/evenly/blok/global/exception/dto/ServerErrorResponse.java
@@ -1,0 +1,29 @@
+package com.evenly.blok.global.exception.dto;
+
+import com.evenly.blok.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ServerErrorResponse extends ErrorResponse {
+
+    private final ErrorDetail error;
+
+    private ServerErrorResponse(ErrorCode errorCode, ErrorDetail error) {
+        super(errorCode);
+        this.error = error;
+    }
+
+    public static ServerErrorResponse of(ErrorCode errorCode, Exception ex) {
+        ErrorDetail errorDetail = new ErrorDetail(ex);
+        return new ServerErrorResponse(errorCode, errorDetail);
+    }
+
+    private record ErrorDetail(String exception,
+                               String message,
+                               String stackTrace) {
+
+        private ErrorDetail(Exception ex) {
+            this(ex.getClass().getSimpleName(), ex.getMessage(), ex.getStackTrace()[0].getClassName());
+        }
+    }
+}

--- a/src/main/java/com/evenly/blok/global/exception/dto/ValidationErrorResponse.java
+++ b/src/main/java/com/evenly/blok/global/exception/dto/ValidationErrorResponse.java
@@ -24,11 +24,11 @@ public class ValidationErrorResponse extends ErrorResponse {
         return new ValidationErrorResponse(errorCode, fieldErrorDetails);
     }
 
-    public record FieldErrorDetail(String field,
-                                   String message,
-                                   Object value) {
+    private record FieldErrorDetail(String field,
+                                    String message,
+                                    Object value) {
 
-        public FieldErrorDetail(FieldError fieldError) {
+        private FieldErrorDetail(FieldError fieldError) {
             this(fieldError.getField(), fieldError.getDefaultMessage(), fieldError.getRejectedValue());
         }
     }

--- a/src/main/java/com/evenly/blok/global/exception/dto/ValidationErrorResponse.java
+++ b/src/main/java/com/evenly/blok/global/exception/dto/ValidationErrorResponse.java
@@ -1,0 +1,35 @@
+package com.evenly.blok.global.exception.dto;
+
+import com.evenly.blok.global.exception.ErrorCode;
+import java.util.List;
+import lombok.Getter;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+@Getter
+public class ValidationErrorResponse extends ErrorResponse {
+
+    private final List<FieldErrorDetail> errors;
+
+    private ValidationErrorResponse(ErrorCode errorCode, List<FieldErrorDetail> errors) {
+        super(errorCode);
+        this.errors = errors;
+    }
+
+    public static ValidationErrorResponse of(ErrorCode errorCode, MethodArgumentNotValidException ex) {
+        List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
+        List<FieldErrorDetail> fieldErrorDetails = fieldErrors.stream()
+                .map(FieldErrorDetail::new)
+                .toList();
+        return new ValidationErrorResponse(errorCode, fieldErrorDetails);
+    }
+
+    public record FieldErrorDetail(String field,
+                                   String message,
+                                   Object value) {
+
+        public FieldErrorDetail(FieldError fieldError) {
+            this(fieldError.getField(), fieldError.getDefaultMessage(), fieldError.getRejectedValue());
+        }
+    }
+}

--- a/src/main/java/com/evenly/blok/global/response/GlobalResponseHandler.java
+++ b/src/main/java/com/evenly/blok/global/response/GlobalResponseHandler.java
@@ -28,13 +28,10 @@ public class GlobalResponseHandler implements ResponseBodyAdvice<Object> {
 
         if (body instanceof ErrorResponse errorResponse) {
             response.setStatusCode(errorResponse.getStatus());
-            return errorResponse;
         }
-        if (body instanceof String) {
-            return body;
+        if (body instanceof SuccessResponse successResponse) {
+            response.setStatusCode(successResponse.getStatus());
         }
-        SuccessResponse successResponse = SuccessResponse.of(body);
-        response.setStatusCode(successResponse.getStatus());
-        return successResponse;
+        return body;
     }
 }

--- a/src/main/java/com/evenly/blok/global/response/GlobalResponseHandler.java
+++ b/src/main/java/com/evenly/blok/global/response/GlobalResponseHandler.java
@@ -1,0 +1,40 @@
+package com.evenly.blok.global.response;
+
+import com.evenly.blok.global.exception.dto.ErrorResponse;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice
+public class GlobalResponseHandler implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType,
+                            Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body,
+                                  MethodParameter returnType,
+                                  MediaType selectedContentType,
+                                  Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                  ServerHttpRequest request,
+                                  ServerHttpResponse response) {
+
+        if (body instanceof ErrorResponse errorResponse) {
+            response.setStatusCode(errorResponse.getStatus());
+            return errorResponse;
+        }
+        if (body instanceof String) {
+            return body;
+        }
+        SuccessResponse successResponse = SuccessResponse.of(body);
+        response.setStatusCode(successResponse.getStatus());
+        return successResponse;
+    }
+}

--- a/src/main/java/com/evenly/blok/global/response/SuccessResponse.java
+++ b/src/main/java/com/evenly/blok/global/response/SuccessResponse.java
@@ -1,0 +1,24 @@
+package com.evenly.blok.global.response;
+
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class SuccessResponse {
+
+    private static final HttpStatus DEFAULT_HTTP_STATUS = HttpStatus.OK;
+    private static final String DEFAULT_MESSAGE = "요청이 성공적으로 처리되었습니다.";
+
+    private final HttpStatus status;
+    private final String message;
+    private final LocalDateTime timestamp;
+    private final Object data;
+
+    public static SuccessResponse of(Object data) {
+        return new SuccessResponse(DEFAULT_HTTP_STATUS, DEFAULT_MESSAGE, LocalDateTime.now(), data);
+    }
+}

--- a/src/main/java/com/evenly/blok/global/response/SuccessResponse.java
+++ b/src/main/java/com/evenly/blok/global/response/SuccessResponse.java
@@ -21,4 +21,8 @@ public class SuccessResponse {
     public static SuccessResponse of(Object data) {
         return new SuccessResponse(DEFAULT_HTTP_STATUS, DEFAULT_MESSAGE, LocalDateTime.now(), data);
     }
+
+    public static SuccessResponse of(HttpStatus status, Object data) {
+        return new SuccessResponse(status, DEFAULT_MESSAGE, LocalDateTime.now(), data);
+    }
 }


### PR DESCRIPTION
issue #2 

## 💻 수정 사항
ErrorResponse가 불필요한 정보 없이 필요한 정보만 담도록 하다보니 돌고돌아 저번 프로젝트에서 사용하던 방식이 되었는데요, 다른 방식을 원하신다면 얼마든지 코드 리뷰 남겨주세요!

제가 의도한 사용 예시는 아래와 같습니다.

아래 클래스를 통해 비즈니스 로직에서 발생시킬 예외 코드를 도메인별로 나누어 정의합니다.
```java
@Getter
@AllArgsConstructor
public enum XXXErrorCode implements ErrorCode {

    NOT_FOUND(BAD_REQUEST, "해당 명함이 존재하지 않습니다."),
    INVALID_MEMBER(BAD_REQUEST, "유효하지 않은 사용자입니다."),
    ;

    private final HttpStatus status;
    private final String message;

    @Override
    public ErrorResponse getResponse() {
        return new ErrorResponse(message);
    }
}
```

그리고 비즈니스 로직에서는 아래와 같이 예외를 발생시킵니다.
```java
public void throwException() {
    throw new BlokException(TestErrorCode.NOT_FOUND);
}
```

## ⛳️ 고민 사항
예외 핸들러 구현과 더불어 글로벌 요청/응답 클래스 구현하기를 담당했는데요! 아직 글로벌 요청/응답 클래스를 구현해본 적이 없고, 필요성을 느끼지 못하는 상태라 구현하지 않고 먼저 PR 요청합니다. 제가 이해한 글로벌 응답 클래스는 [이러한 것](https://github.com/depromeet/10mm-server/blob/develop/src/main/java/com/depromeet/global/common/response/GlobalResponseAdvice.java)인데, 제가 잘 이해한 게 맞는지 궁금하고, 다른 사례가 있다면 알려주시면 감사하겠습니다 :)